### PR TITLE
Add auto-scaling by CPU on all envs and scheduled scaling on staging

### DIFF
--- a/groups/ecs-service/locals.tf
+++ b/groups/ecs-service/locals.tf
@@ -5,7 +5,7 @@ locals {
   service_name              = "docs-developer"
   container_port            = "8080" # default tomcat port required here until prod docker container is built allowing port change via env var
   docker_repo               = "docs.developer.ch.gov.uk"
-  lb_listener_rule_priority = 100
+  lb_listener_rule_priority = 10
   lb_listener_paths         = ["/*"]
   vpc_name                  = data.aws_ssm_parameter.secret[format("/%s/%s", local.name_prefix, "vpc-name")].value
 

--- a/groups/ecs-service/main.tf
+++ b/groups/ecs-service/main.tf
@@ -31,6 +31,7 @@ module "ecs-service" {
   lb_listener_arn           = data.aws_lb_listener.dev-site-lb-listener.arn
   lb_listener_rule_priority = local.lb_listener_rule_priority
   lb_listener_paths         = local.lb_listener_paths
+  healthcheck_path          = "/"
 
   # Docker container details
   docker_registry   = var.docker_registry

--- a/groups/ecs-service/main.tf
+++ b/groups/ecs-service/main.tf
@@ -18,7 +18,7 @@ terraform {
 }
 
 module "ecs-service" {
-  source = "git::git@github.com:companieshouse/terraform-library-ecs-service.git?ref=1.0.2"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.206"
 
   # Environmental configuration
   environment             = var.environment
@@ -43,9 +43,14 @@ module "ecs-service" {
   name_prefix  = local.name_prefix
 
   # Service performance and scaling configs
-  desired_task_count = var.desired_task_count
-  required_cpus      = var.required_cpus
-  required_memory    = var.required_memory
+  desired_task_count                 = var.desired_task_count
+  max_task_count                     = var.max_task_count
+  required_cpus                      = var.required_cpus
+  required_memory                    = var.required_memory
+  service_autoscale_enabled          = var.service_autoscale_enabled
+  service_autoscale_target_value_cpu = var.service_autoscale_target_value_cpu
+  service_scaledown_schedule         = var.service_scaledown_schedule
+  service_scaleup_schedule           = var.service_scaleup_schedule
 
   # Service environment variable and secret configs
   task_environment = local.task_environment

--- a/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -18,3 +18,7 @@ cookie_domain = "company-information.service.gov.uk"
 oauth2_redirect_uri = "https://developer-staging.company-information.service.gov.uk/oauth2/user/callback"
 oauth2_auth_uri = "https://identity-staging.company-information.service.gov.uk/oauth2/authorise"
 redirect_uri = "https://developer-staging.company-information.service.gov.uk"
+
+# Scheduled scaling of tasks
+service_scaledown_schedule = "55 19 * * ? *"
+service_scaleup_schedule   = "5 6 * * ? *"

--- a/groups/ecs-service/variables.tf
+++ b/groups/ecs-service/variables.tf
@@ -52,6 +52,11 @@ variable "desired_task_count" {
   description = "The desired ECS task count for this service"
   default = 1 # defaulted low for dev environments, override for production
 }
+variable "max_task_count" {
+  type        = number
+  description = "The maximum number of tasks for this service."
+  default     = 3
+}
 variable "required_cpus" {
   type = number
   description = "The required cpu resource for this service. 1024 here is 1 vCPU"
@@ -61,6 +66,26 @@ variable "required_memory" {
   type = number
   description = "The required memory for this service"
   default = 256 # defaulted low for java service in dev environments, override for production
+}
+variable "service_autoscale_enabled" {
+  type        = bool
+  description = "Whether to enable service autoscaling, including scheduled autoscaling"
+  default     = true
+}
+variable "service_autoscale_target_value_cpu" {
+  type        = number
+  description = "Target CPU percentage for the ECS Service to autoscale on"
+  default     = 50 # 100 disables autoscaling using CPU as a metric
+}
+variable "service_scaledown_schedule" {
+  type        = string
+  description = "The schedule to use when scaling down the number of tasks to zero."
+  default     = ""
+}
+variable "service_scaleup_schedule" {
+  type        = string
+  description = "The schedule to use when scaling up the number of tasks to their normal desired level."
+  default     = ""
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Adds a scheduled shutdown/startup on staging, and auto-scaling based on CPU on all envs.

- Uses the module ecs-service from terraform-modules instead of terraform-library-ecs-service to bring in service auto-scaling feature.
- Adjusts the lb rule priority to match the current active setting as the new ecs-service module uses "amped" (x10) values.  Also overrides the health check path to "/".
- Configures an overnight shutdown/startup schedule for the service on staging only, so that the number of tasks is scaled to zero just before the scheduled ASG scale down happens, and scaled up to the desired count just after the ASG scale up happens.
- Enables target tracking of average CPU with a value of 50%, so if that level is exceeded the number of tasks will scale up (to max of 3) and scale down to at least 1 if CPU is below 50%.

Partially resolves:
https://companieshouse.atlassian.net/browse/CC-198
