### PR TITLE
Override healthcheck_healthy_threshold to set to 2

### DIFF
--- a/groups/ecs-service/main.tf
+++ b/groups/ecs-service/main.tf
@@ -33,6 +33,7 @@ module "ecs-service" {
   lb_listener_paths                 = local.lb_listener_paths
   healthcheck_path                  = "/"
   health_check_grace_period_seconds = 240
+  healthcheck_healthy_threshold     = "2"
 
   # Docker container details
   docker_registry   = var.docker_registry


### PR DESCRIPTION
Reduce the time the service takes to be considered healthy by the ALB, by reducing the number of health cehcks required.

The service is failing to stabilise and the deployment onto ECS is being failed, even with a large health check grace period of 240 secs.  The issue is that, by default, 5 health checks are needed before the ALB will declare the target group/task healthy, and it takes > 90 secs to start, so it takes >90 secs + up to 5 x 30 secs, to become healthy, by which time ECS marks the deployment as failed.