### PR TITLE
Use a capacity provider to allow ASG to be scaled

### DIFF
--- a/groups/ecs-service/main.tf
+++ b/groups/ecs-service/main.tf
@@ -18,7 +18,7 @@ terraform {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.208"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.209"
 
   # Environmental configuration
   environment             = var.environment
@@ -54,6 +54,7 @@ module "ecs-service" {
   service_autoscale_target_value_cpu = var.service_autoscale_target_value_cpu
   service_scaledown_schedule         = var.service_scaledown_schedule
   service_scaleup_schedule           = var.service_scaleup_schedule
+  use_capacity_provider              = var.use_capacity_provider
 
   # Service environment variable and secret configs
   task_environment = local.task_environment

--- a/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -5,6 +5,9 @@ deploy_to = "development"
 state_prefix = "env:/development"
 aws_profile = "development-eu-west-2"
 
+required_memory = 512
+max_task_count = 8
+
 # service configs
 log_level = "trace"
 cdn_host = "d3uvya5a8a1ncx.cloudfront.net"

--- a/groups/ecs-service/variables.tf
+++ b/groups/ecs-service/variables.tf
@@ -67,6 +67,11 @@ variable "required_memory" {
   description = "The required memory for this service"
   default = 256 # defaulted low for java service in dev environments, override for production
 }
+variable "use_capacity_provider" {
+  type        = bool
+  description = "Whether to use a capacity provider instead of setting a launch type for the service"
+  default     = true
+}
 variable "service_autoscale_enabled" {
   type        = bool
   description = "Whether to enable service autoscaling, including scheduled autoscaling"


### PR DESCRIPTION
Enables the use of the cluster EC2 capacity provider for the docs developer service

Also increases max tasks and memory, just on cidev, to enable the scale out/in to be tested (otherwise we would not be able to exceed the capacity of a single EC2 instance).

Resolves:
https://companieshouse.atlassian.net/browse/CC-292


**don't merge until the developer-site stack on CIDEV has been updated to enable the capacity provider**