### PR TITLE
Pass aws_profile var to ecs-service module

### DIFF
--- a/groups/ecs-service/main.tf
+++ b/groups/ecs-service/main.tf
@@ -24,6 +24,7 @@ module "ecs-service" {
   # Environmental configuration
   environment             = var.environment
   aws_region              = var.aws_region
+  aws_profile             = var.aws_profile
   vpc_id                  = data.aws_vpc.vpc.id
   ecs_cluster_id          = data.aws_ecs_cluster.ecs_cluster.id
   task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn


### PR DESCRIPTION
The updated ecs-service module now requires the aws_profile to be set.

Resolves:
https://companieshouse.atlassian.net/browse/CC-855
